### PR TITLE
Fix: Detención de propagación del evento delete para suite de test

### DIFF
--- a/src/components/modals/new-exercise/new-exercise.js
+++ b/src/components/modals/new-exercise/new-exercise.js
@@ -116,7 +116,7 @@ export default {
 
     deleteTest(indexTest) {
       this.tests.splice(indexTest, 1);
-      if (this.currentIndexTest == indexTest) {
+      if (this.currentIndexTest === indexTest) {
         this.currentIndexTest = -1;
         this.currentTestCode = "";
         this.currentTestName = "";
@@ -288,14 +288,6 @@ export default {
   mounted() {
     this.$root.$on("bv::modal::show", () => {
       this.resetModal();
-
-      //Inicialización generación de test
-      this.folder = "TEST FOLDER";
-      this.solutionCode = "let resultado = [a, b];";
-      this.tests = [
-        { name: "TEST 1", test: "let a = 1; let b = 1;" },
-        { name: "TEST 2", test: "let a = 2; let b = 2;" },
-      ];
     });
 
     // this.$root.$on("bv::modal::shown", () => {

--- a/src/components/modals/new-exercise/new-exercise.vue
+++ b/src/components/modals/new-exercise/new-exercise.vue
@@ -158,7 +158,7 @@
               <font-awesome-icon
                 class="new-exercise__test--item--delete"
                 :icon="['fas', 'trash-alt']"
-                @click="deleteTest(i)"
+                @click.prevent.stop="deleteTest(i)"
               />
             </div>
           </template>


### PR DESCRIPTION
Se evito la propagación del evento click, el cual estaba disparando un showTest() no deseado, además de arrojar un error por consola en ciertos escenarios. 
Por otro lado se eliminaron los datos iniciales para la creación de ejercicios. 